### PR TITLE
Bug Fixes : Unable to perform Python Broadcast due to rank array

### DIFF
--- a/image_reconstruction_using_PCA.py
+++ b/image_reconstruction_using_PCA.py
@@ -6,8 +6,8 @@ import matplotlib.pyplot as plt
 import numpy as np 
 from PIL import Image
 
-# IMPORTING IMAGE USING SCIPY AND TAKING R,G,B COMPONENTS
-
+# IMPORTING IMAGE USING Matplotlib AND TAKING R,G,B COMPONENTS
+#a = scipy.ndimage.imread("dhoni.jpg") #In my laptop it ws not able to invoke imread, so imported image via plt.imread
 a = plt.imread("dhoni.jpg")
 a_np = np.array(a)
 a_r = a_np[:,:,0]

--- a/image_reconstruction_using_PCA.py
+++ b/image_reconstruction_using_PCA.py
@@ -8,34 +8,30 @@ from PIL import Image
 
 # IMPORTING IMAGE USING SCIPY AND TAKING R,G,B COMPONENTS
 
-a = scipy.ndimage.imread("dhoni.jpg")
+a = plt.imread("dhoni.jpg")
 a_np = np.array(a)
 a_r = a_np[:,:,0]
 a_g = a_np[:,:,1]
 a_b = a_np[:,:,2]
 
 def comp_2d(image_2d): # FUNCTION FOR RECONSTRUCTING 2D MATRIX USING PCA
-	cov_mat = image_2d - np.mean(image_2d , axis = 1)
-	eig_val, eig_vec = np.linalg.eigh(np.cov(cov_mat)) # USING "eigh", SO THAT PROPRTIES OF HERMITIAN MATRIX CAN BE USED
-	p = np.size(eig_vec, axis =1)
-	idx = np.argsort(eig_val)
-	idx = idx[::-1]
-	eig_vec = eig_vec[:,idx]
-	eig_val = eig_val[idx]
-	numpc = 100 # THIS IS NUMBER OF PRINCIPAL COMPONENTS, YOU CAN CHANGE IT AND SEE RESULTS
-	if numpc <p or numpc >0:
-		eig_vec = eig_vec[:, range(numpc)]
-	score = np.dot(eig_vec.T, cov_mat)
-	recon = np.dot(eig_vec, score) + np.mean(image_2d, axis = 1).T # SOME NORMALIZATION CAN BE USED TO MAKE IMAGE QUALITY BETTER
-	recon_img_mat = np.uint8(np.absolute(recon)) # TO CONTROL COMPLEX EIGENVALUES
-	return recon_img_mat
+    cov_mat = image_2d - np.mean(image_2d , axis = 1 ,keepdims=True)
+    eig_val, eig_vec = np.linalg.eigh(np.cov(cov_mat)) # USING "eigh", SO THAT PROPRTIES OF HERMITIAN MATRIX CAN BE USED
+    p = np.size(eig_vec, axis =1)
+    idx = np.argsort(eig_val)
+    idx = idx[::-1]
+    eig_vec = eig_vec[:,idx]
+    eig_val = eig_val[idx]
+    numpc = 100 # THIS IS NUMBER OF PRINCIPAL COMPONENTS, YOU CAN CHANGE IT AND SEE RESULTS
+    if numpc <p or numpc >0:
+        eig_vec = eig_vec[:, range(numpc)]
+    score = np.dot(eig_vec.T, cov_mat)
+    recon = np.dot(eig_vec, score) + np.mean(image_2d, axis = 1,keepdims=True) # SOME NORMALIZATION CAN BE USED TO MAKE IMAGE QUALITY BETTER
+    recon_img_mat = np.uint8(np.absolute(recon)) # TO CONTROL COMPLEX EIGENVALUES
+    return recon_img_mat
 
 a_r_recon, a_g_recon, a_b_recon = comp_2d(a_r), comp_2d(a_g), comp_2d(a_b) # RECONSTRUCTING R,G,B COMPONENTS SEPARATELY
 recon_color_img = np.dstack((a_r_recon, a_g_recon, a_b_recon)) # COMBINING R.G,B COMPONENTS TO PRODUCE COLOR IMAGE
 recon_color_img = Image.fromarray(recon_color_img)
 recon_color_img.show()
-
-
-
-
-
+recon_color_img.save("dhoni_compressed.jpg")


### PR DESCRIPTION
**Error Encountered** : 

**ValueError** : operands could not be broadcast together with shapes (4000,6000) (4000,)

**Fix** : 
The np.mean function used during `cov_mat = image_2d - np.mean()...` and `recon = np.dot .....` resulted in a rank array instead of dimensional 1 D vector, due to which python broadcasting failed and ValueError was encountered. The code has been fixed  by adding the `keepdims = True` parameter which then results in (4000,1) vector and not (4000,) rank.

**Status : Issue Resolved**

Regards,
Keshav Tangri
![errorGithub](https://user-images.githubusercontent.com/28071802/83638461-d0002700-a5c6-11ea-8fb3-f8d7820bd6d8.png)
